### PR TITLE
support for -no-target-directory

### DIFF
--- a/src/drivers/simple.rs
+++ b/src/drivers/simple.rs
@@ -109,7 +109,7 @@ fn copy_source(
         msg: "Failed to find source directory name.",
     })?;
 
-    let target_base = if dest.exists() {
+    let target_base = if dest.exists() && !opts.no_target_directory {
         dest.join(sourcedir)
     } else {
         dest.clone()

--- a/src/options.rs
+++ b/src/options.rs
@@ -71,6 +71,9 @@ pub struct Opts {
     #[structopt(long = "driver")]
     pub driver: Option<Drivers>,
 
+    /// Analagous to cp's no-target-directory. Expected behavior is that when
+    /// copying a directory to another directory, instead of creating a sub-folder
+    /// in target, overwrite target.
     #[structopt(short = "T", long = "no-target-directory" )]
     pub no_target_directory: bool,
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -71,6 +71,9 @@ pub struct Opts {
     #[structopt(long = "driver")]
     pub driver: Option<Drivers>,
 
+    #[structopt(short = "T", long = "no-target-directory" )]
+    pub no_target_directory: bool,
+
     #[structopt(required = true, min_values = 2 )]
     pub paths: Vec<String>,
 


### PR DESCRIPTION
add option for no-target-directory, analagous to cp's
no-target-directory. Expected behavior is that when copying a directory
to another directory, instead of creating a sub-folder in target,
overwrite target.