### PR TITLE
Check opts.noclobber before calling exists

### DIFF
--- a/src/drivers/parblock.rs
+++ b/src/drivers/parblock.rs
@@ -213,7 +213,7 @@ pub fn copy_all(sources: Vec<PathBuf>, dest: PathBuf, opts: &Opts) -> Result<()>
                 target_base.clone()
             };
 
-            if target.exists() && opts.noclobber {
+            if opts.noclobber && target.exists() {
                 return Err(XcpError::DestinationExists(
                     "Destination file exists and --no-clobber is set.",
                     target,

--- a/src/drivers/parfile.rs
+++ b/src/drivers/parfile.rs
@@ -131,7 +131,7 @@ fn copy_source(
             target_base.clone()
         };
 
-        if target.exists() && opts.noclobber {
+        if opts.noclobber && target.exists() {
             work_tx.send(Operation::End)?;
             updates.update(Err(XcpError::DestinationExists(
                 "Destination file exists and --no-clobber is set.",


### PR DESCRIPTION
This avoids a syscall which can be very slow on some file systems.