### PR TITLE
Fix typos

### DIFF
--- a/src/drivers/parfile.rs
+++ b/src/drivers/parfile.rs
@@ -77,7 +77,7 @@ fn copy_worker(
             Operation::Copy(from, to) => {
                 info!("Worker: Copy {:?} -> {:?}", from, to);
                 // copy_file sends back its own updates, but we should
-                // send back any errors as they may have occured
+                // send back any errors as they may have occurred
                 // before the copy started..
                 let r = copy_file(&from, &to, opts, &mut updates);
                 if r.is_err() {

--- a/src/options.rs
+++ b/src/options.rs
@@ -85,7 +85,7 @@ pub struct Opts {
     #[structopt(long = "driver")]
     pub driver: Option<Drivers>,
 
-    /// Analagous to cp's no-target-directory. Expected behavior is that when
+    /// Analogous to cp's no-target-directory. Expected behavior is that when
     /// copying a directory to another directory, instead of creating a sub-folder
     /// in target, overwrite target.
     #[structopt(short = "T", long = "no-target-directory" )]

--- a/src/vendor/threadpool.rs
+++ b/src/vendor/threadpool.rs
@@ -1274,7 +1274,7 @@ mod test {
     #[ignore]
     /// The scenario is joining threads should not be stuck once their wave
     /// of joins has completed. So once one thread joining on a pool has
-    /// succeded other threads joining on the same pool must get out even if
+    /// succeeded other threads joining on the same pool must get out even if
     /// the thread is used for other jobs while the first group is finishing
     /// their join
     ///


### PR DESCRIPTION
Found via `codespell -L crate`.