### PR TITLE
CI: detect test feature flags based on current filesystem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,32 +18,25 @@ jobs:
         run: tests/scripts/make-filesystems.sh ext2 ext4 xfs btrfs ntfs fat zfs
 
       - name: Run tests on ext2
-        run: cargo test --workspace --features=test_no_extents,test_no_reflink
-        working-directory: /fs/ext2/src
+        run: /fs/ext2/src/tests/scripts/test-linux.sh
 
       - name: Run tests on ext4
-        run: cargo test --workspace --features=test_no_reflink
-        working-directory: /fs/ext4/src
+        run: /fs/ext4/src/tests/scripts/test-linux.sh
 
       - name: Run tests on XFS
-        run: cargo test --workspace
-        working-directory: /fs/xfs/src
+        run: /fs/xfs/src/tests/scripts/test-linux.sh
 
       - name: Run tests on btrfs
-        run: cargo test --workspace
-        working-directory: /fs/btrfs/src
+        run: /fs/btrfs/src/tests/scripts/test-linux.sh
 
       - name: Run tests on ntfs
-        run: cargo test --workspace --features=test_no_extents,test_no_sparse,test_no_reflink
-        working-directory: /fs/ntfs/src
+        run: /fs/ntfs/src/tests/scripts/test-linux.sh
 
       - name: Run tests on fat
-        run: cargo test --workspace --features=test_no_extents,test_no_sparse,test_no_sockets,test_no_symlinks,test_no_xattr,test_no_reflink
-        working-directory: /fs/fat/src
+        run: /fs/fat/src/tests/scripts/test-linux.sh
 
       - name: Run tests on ZFS
-        run: cargo test --workspace --features=test_no_extents,test_no_reflink,test_no_sparse
-        working-directory: /fs/zfs/src
+        run: /fs/zfs/src/tests/scripts/test-linux.sh
 
   expensive:
     runs-on: ubuntu-latest
@@ -54,8 +47,7 @@ jobs:
         run: ~/.cargo/bin/rustup update
 
       - name: Run expensive tests
-        # Assume we're running on ext4
-        run: ~/.cargo/bin/cargo test --workspace --features=test_no_reflink,test_run_expensive
+        run: ./tests/scripts/test-linux.sh test_run_expensive
 
   macos:
     runs-on: macos-latest

--- a/tests/scripts/test-linux.sh
+++ b/tests/scripts/test-linux.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+# chdir to source root
+cd "$(dirname "$0")"/../..
+
+# get the name of the filesystem that contains the source code
+fs=$(df --output=fstype . | tail -n 1)
+
+# list features supported by all filesystems
+features=(use_linux "$@")
+
+# disable tests that will not work on this filesystem
+case "$fs" in
+xfs | btrfs | bcachefs) ;;
+
+ext4)
+  features+=(
+    test_no_reflink
+  )
+  ;;
+
+ext[23])
+  features+=(
+    test_no_extents
+    test_no_reflink
+  )
+  ;;
+
+f2fs)
+  features+=(
+    test_no_reflink
+  )
+  ;;
+
+fuseblk)
+  echo >&2 "WARNING: assuming ntfs"
+  features+=(
+    test_no_extents
+    test_no_reflink
+    test_no_sparse
+  )
+  ;;
+
+vfat)
+  features+=(
+    test_no_extents
+    test_no_reflink
+    test_no_sockets
+    test_no_sparse
+    test_no_symlinks
+    test_no_xattr
+  )
+  ;;
+
+tmpfs)
+  features+=(
+    test_no_extents
+    test_no_reflink
+    test_no_sparse
+  )
+  ;;
+
+zfs)
+  features+=(
+    test_no_extents
+    test_no_reflink
+    test_no_sparse
+  )
+  ;;
+
+*)
+  echo >&2 "WARNING: unknown filesystem $fs, some tests might fail"
+  ;;
+esac
+
+echo >&2 "found filesystem $fs, using flags ${features[*]}"
+
+cargo test --workspace --release --locked --features "$(
+  export IFS=,
+  echo "${features[*]}"
+)"


### PR DESCRIPTION
This script can be used both by CI and by packaging scripts like the Arch Linux PKGBUILD.

I'd rather not disable tests altogether because some users tend to experiment a lot and thus run weird configurations and bleeding edge filesystems, so tests might very well detect real problems before xcp is used for real work.

I believe most Arch users build their own AUR packages and not use prebuilt repos.

closes #43