### PR TITLE
enable xcp as a lib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod drivers;
+pub mod options;
+pub mod operations;
+pub mod errors;
+pub mod progress;
+mod utils;


### PR DESCRIPTION
I'm using xcp in https://github.com/lengyijun/smartscp/tree/sshfs