### PR TITLE
fix(xcp): treat source roots that are symlinks the same as deeper symlinks

### DIFF
--- a/libxcp/src/operations.rs
+++ b/libxcp/src/operations.rs
@@ -186,7 +186,7 @@ pub fn tree_walker(
 
         let gitignore = parse_ignore(&source, config)?;
 
-        for entry in WalkDir::new(&source)
+        for entry in WalkDir::new(&source).follow_root_links(false)
             .into_iter()
             .filter_entry(|e| ignore_filter(e, &gitignore))
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,11 +118,11 @@ fn main() -> Result<()> {
     // Sanity-check all sources up-front
     for source in &sources {
         info!("Copying source {source:?} to {dest:?}");
-        if !source.exists() {
-            return Err(XcpError::InvalidSource("Source does not exist.").into());
-        }
+        let metadata = source.symlink_metadata().map_err(|_|
+            XcpError::InvalidSource("Source does not exist, or perhaps you lack permission to access it.")
+        )?;
 
-        if source.is_dir() && !opts.recursive {
+        if metadata.is_dir() && !opts.recursive {
             return Err(XcpError::InvalidSource("Source is directory and --recursive not specified.").into());
         }
         if source == &dest {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -53,7 +53,72 @@ fn source_missing(drv: &str) {
     assert!(out.status.code().unwrap() == 1);
 
     let stderr = String::from_utf8(out.stderr).unwrap();
-    assert!(stderr.contains("Source does not exist"));
+    assert!(stderr.contains("Source does not exist, or perhaps"));
+}
+
+#[cfg_attr(feature = "parblock", test_case("parblock"; "Test with parallel block driver"))]
+#[test_case("parfile"; "Test with parallel file driver")]
+#[cfg_attr(feature = "test_no_symlinks", ignore = "No FS support")]
+fn source_broken_symlink(drv: &str) {
+    let dir = tempdir_rel().unwrap();
+    let source_path = dir.path().join("broken-symlink");
+    let dest_path = dir.path().join("broken-symlink-copy");
+    symlink("/this/should/not/exist", &source_path).unwrap();
+
+    let out = run(&["--driver", drv,
+        source_path.to_str().unwrap(),
+        dest_path.to_str().unwrap(),
+    ]).unwrap();
+
+    assert!(out.status.success());
+    assert!(files_match(&source_path, &dest_path));
+}
+
+#[cfg_attr(feature = "parblock", test_case("parblock"; "Test with parallel block driver"))]
+#[test_case("parfile"; "Test with parallel file driver")]
+#[cfg_attr(feature = "test_no_symlinks", ignore = "No FS support")]
+fn source_symlink(drv: &str) {
+    let dir = tempdir_rel().unwrap();
+    let source_file = dir.path().join("file.txt");
+    let source_link = dir.path().join("link.txt");
+    create_file(&source_file, "orig").unwrap();
+    symlink("file.txt", &source_link).unwrap();
+    let dest = dir.path().join("dest");
+
+    let out = run(&[
+        "--driver", drv,
+        source_link.to_str().unwrap(),
+        dest.to_str().unwrap(),
+    ])
+    .unwrap();
+
+    assert!(out.status.success());
+    assert!(files_match(&source_link, &dest));
+}
+
+#[cfg_attr(feature = "parblock", test_case("parblock"; "Test with parallel block driver"))]
+#[test_case("parfile"; "Test with parallel file driver")]
+#[cfg_attr(feature = "test_no_symlinks", ignore = "No FS support")]
+fn source_symlink_deref(drv: &str) {
+    let dir = tempdir_rel().unwrap();
+    let source_file = dir.path().join("file.txt");
+    let source_link = dir.path().join("link.txt");
+    create_file(&source_file, "orig").unwrap();
+    symlink("file.txt", &source_link).unwrap();
+    let dest = dir.path().join("dest");
+
+    let out = run(&[
+        "--driver", drv,
+        "--dereference",
+        source_link.to_str().unwrap(),
+        dest.to_str().unwrap(),
+    ])
+    .unwrap();
+
+    assert!(out.status.success());
+    // The destination should make the `source_file` that the `source_link` (the thing we gave to
+    // xcp) points at.
+    assert!(files_match(&source_file, &dest));
 }
 
 #[cfg_attr(feature = "parblock", test_case("parblock"; "Test with parallel block driver"))]

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -116,25 +116,32 @@ pub fn file_contains(path: &Path, text: &str) -> Result<bool, Error> {
 
 pub fn files_match(a: &Path, b: &Path) -> bool {
     println!("Checking: {a:?}");
-    if a.metadata().unwrap().len() != b.metadata().unwrap().len() {
+    let a_metadata = a.symlink_metadata().unwrap();
+    let b_metadata = b.symlink_metadata().unwrap();
+    if a_metadata.len() != b_metadata.len() {
         return false;
     }
-    let mut abr = BufReader::with_capacity(1024 * 1024, File::open(a).unwrap());
-    let mut bbr = BufReader::with_capacity(1024 * 1024, File::open(b).unwrap());
-    loop {
-        let read = {
-            let ab = abr.fill_buf().unwrap();
-            let bb = bbr.fill_buf().unwrap();
-            if ab != bb {
-                return false;
-            }
-            if ab.is_empty() {
-                return true;
-            }
-            ab.len()
-        };
-        abr.consume(read);
-        bbr.consume(read);
+
+    if a_metadata.is_symlink() || b_metadata.is_symlink() {
+        a.read_link().unwrap() == b.read_link().unwrap()
+    } else {
+        let mut abr = BufReader::with_capacity(1024 * 1024, File::open(a).unwrap());
+        let mut bbr = BufReader::with_capacity(1024 * 1024, File::open(b).unwrap());
+        loop {
+            let read = {
+                let ab = abr.fill_buf().unwrap();
+                let bb = bbr.fill_buf().unwrap();
+                if ab != bb {
+                    return false;
+                }
+                if ab.is_empty() {
+                    return true;
+                }
+                ab.len()
+            };
+            abr.consume(read);
+            bbr.consume(read);
+        }
     }
 }
 


### PR DESCRIPTION
Previously, we'd unconditionally dereference source roots that are symlinks. This had some surprising behavior: we couldn't copy broken symlinks, and we'd treat symlinks to directories as directories (which would do some pretty weird stuff: we'd correctly copy the root symlink, but still recurse through the entire directory and copy all the files inside of it, doing a bunch of unnecessary work where we'd just be copying every file on top of itself).

Now we do treat symlinks the same regardless of if their the root of a source, or deep inside of a source:
- By default we treat them as opaque things that are cheap to copy.
- Unless `--dereference` is passed, in which case we follow the symlink and copy the target file/folder accordingly.

This fixes https://github.com/tarka/xcp/issues/52