### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.9](https://github.com/tarka/xcp/compare/xcp-v0.24.8...xcp-v0.24.9) - 2026-06-23
+
+### <!-- 3 -->Documentation
+
+- Add SECURITY.md
+
+### Other
+
+- Dependency update
+- Typo
+
 ## [0.24.8](https://github.com/tarka/xcp/compare/xcp-v0.24.7...xcp-v0.24.8) - 2026-05-03
 
 ### <!-- 1 -->Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfs"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cfg-if",
  "exacl",
@@ -421,7 +421,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libxcp"
-version = "0.24.5"
+version = "0.24.6"
 dependencies = [
  "anyhow",
  "blocking-threadpool",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "xcp"
-version = "0.24.8"
+version = "0.24.9"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [package]
 name = "xcp"
 description = "xcp is a (partial) clone of the Unix `cp` command, with more user-friendly feedback and some performance optimisations. See the README for features and limitations."
-version = "0.24.8"
+version = "0.24.9"
 rust-version = "1.88.0"
 edition = "2024"
 
@@ -48,8 +48,8 @@ clap = { version = "4.6.1", features = ["derive"] }
 glob = "0.3.3"
 ignore = "0.4.26"
 indicatif = "0.18.4"
-libfs = { version = "0.9.4", path = "libfs" }
-libxcp = { version = "0.24.5", path = "libxcp" }
+libfs = { version = "0.9.5", path = "libfs" }
+libxcp = { version = "0.24.6", path = "libxcp" }
 log = "0.4.33"
 num_cpus = "1.17.0"
 simplelog = "0.12.2"

--- a/libfs/CHANGELOG.md
+++ b/libfs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.5](https://github.com/tarka/xcp/compare/libfs-v0.9.4...libfs-v0.9.5) - 2026-06-23
+
+### Other
+
+- Dependency update
+
 ## [0.9.4](https://github.com/tarka/xcp/compare/libfs-v0.9.3...libfs-v0.9.4) - 2026-05-03
 
 ### <!-- 1 -->Bug Fixes

--- a/libfs/Cargo.toml
+++ b/libfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libfs"
 description = "`libfs` is a library of file and filesystem operations that is supplementary to `std::fs`"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 rust-version = "1.88.0"
 

--- a/libxcp/CHANGELOG.md
+++ b/libxcp/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.6](https://github.com/tarka/xcp/compare/libxcp-v0.24.5...libxcp-v0.24.6) - 2026-06-23
+
+### Other
+
+- Dependency update
+- Typo
+
 ## [0.24.5](https://github.com/tarka/xcp/compare/libxcp-v0.24.4...libxcp-v0.24.5) - 2026-05-03
 
 ### <!-- 1 -->Bug Fixes

--- a/libxcp/Cargo.toml
+++ b/libxcp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libxcp"
 description = "`libxcp` is a high-level file-copy engine with support for multi-threading, fine-grained progress feedback, pluggable drivers, and `.gitignore` filters. `libxcp` provides the core functionality of `xcp`."
-version = "0.24.5"
+version = "0.24.6"
 edition = "2024"
 rust-version = "1.88.0"
 
@@ -25,7 +25,7 @@ blocking-threadpool = "1.0.3"
 cfg-if = "1.0.4"
 crossbeam-channel = "0.5.15"
 ignore = "0.4.26"
-libfs = { version = "0.9.4", path = "../libfs" }
+libfs = { version = "0.9.5", path = "../libfs" }
 log = "0.4.33"
 num_cpus = "1.17.0"
 regex = "1.12.4"


### PR DESCRIPTION



## 🤖 New release

* `libfs`: 0.9.4 -> 0.9.5 (✓ API compatible changes)
* `libxcp`: 0.24.5 -> 0.24.6 (✓ API compatible changes)
* `xcp`: 0.24.8 -> 0.24.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `libfs`

<blockquote>

## [0.9.5](https://github.com/tarka/xcp/compare/libfs-v0.9.4...libfs-v0.9.5) - 2026-06-23

### Other

- Dependency update
</blockquote>

## `libxcp`

<blockquote>

## [0.24.6](https://github.com/tarka/xcp/compare/libxcp-v0.24.5...libxcp-v0.24.6) - 2026-06-23

### Other

- Dependency update
- Typo
</blockquote>

## `xcp`

<blockquote>

## [0.24.9](https://github.com/tarka/xcp/compare/xcp-v0.24.8...xcp-v0.24.9) - 2026-06-23

### <!-- 3 -->Documentation

- Add SECURITY.md

### Other

- Dependency update
- Typo
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).